### PR TITLE
README is misleading on profile definition

### DIFF
--- a/README
+++ b/README
@@ -62,7 +62,7 @@ Installation
             user_id:          integer(4)
             first_name:       varchar(20)
             last_name:        varchar(20)
-            facebook_uid:     integer(4)
+            facebook_uid:     integer(5) # Must be BIGINT to fit Facebook's uids
             email:            varchar(255)
             email_hash:       varchar(255)
           relations:


### PR DESCRIPTION
The README states that your profile table should have an int(4) for the facebook_uid column. For the newer Facebook uid this is too small and wont work. There is a proper warning to use a BIGINT for the column, but this is hidden away inside the plugin's app.yml.

I have fixed the README to show the correct definition and warn about this requirement.
