### PR TITLE
Remove extra getFacebookCookie() method

### DIFF
--- a/lib/sfFacebook.class.php
+++ b/lib/sfFacebook.class.php
@@ -15,7 +15,6 @@ class sfFacebook
   protected static
     $is_js_loaded       = false;
 
-
   public static function getFacebookCookie()
   {
     $app_id = self::getApiId();
@@ -48,35 +47,6 @@ class sfFacebook
    * @since 2010-05-12 Benjamin Grandfond <benjaming@theodo.fr>: new Facebook php-sdk
    * @since 2010-09-03 Benjamin Grandfond : correct the parameters sent to the facebook class constructor
    */
-
-
-  public static function getFacebookCookie()
-  {
-    $app_id = self::getApiKey();
-    $application_secret = self::getApiSecret();
-    $args = array();
-    if (!isset($_COOKIE['fbs_' . $app_id]))
-    {
-      return null;
-    }
-    parse_str(trim($_COOKIE['fbs_' . $app_id], '\\"'), $args);
-    ksort($args);
-    $payload = '';
-    foreach ($args as $key => $value)
-    {
-      if ($key != 'sig')
-      {
-        $payload .= $key . '=' . $value;
-      }
-    }
-    if (md5($payload . $application_secret) != $args['sig'])
-    {
-      return null;
-    }
-    return $args;
-  }
-
-
   public static function getFacebookClient()
   {
     if (self::$client === null)

--- a/lib/sfFacebook.class.php
+++ b/lib/sfFacebook.class.php
@@ -17,9 +17,13 @@ class sfFacebook
 
   public static function getFacebookCookie()
   {
-    $app_id = self::getApiId();
+    $app_id = self::getApiKey();
     $application_secret = self::getApiSecret();
     $args = array();
+    if (!isset($_COOKIE['fbs_' . $app_id]))
+    {
+      return null;
+    }
     parse_str(trim($_COOKIE['fbs_' . $app_id], '\\"'), $args);
     ksort($args);
     $payload = '';
@@ -34,7 +38,6 @@ class sfFacebook
     {
       return null;
     }
-
     return $args;
   }
 


### PR DESCRIPTION
As per https://github.com/fabriceb/sfFacebookConnectPlugin/issues#issue/13

This duplicate method snuck its way into the code in a merge not too long ago. My commit removes it.
