### PR TITLE
Changes to executeSignin()

### DIFF
--- a/modules/sfFacebookConnectAuth/lib/BasesfFacebookConnectAuthActions.class.php
+++ b/modules/sfFacebookConnectAuth/lib/BasesfFacebookConnectAuthActions.class.php
@@ -44,11 +44,11 @@ class BasesfFacebookConnectAuthActions extends sfActions
       &&
       !sfFacebook::getGuardAdapter()->getUserFacebookUid($user->getGuardUser())
       &&
-      sfFacebook::getFacebookClient()->get_loggedin_user()
+      sfFacebook::getFacebookClient()->getUser()
       )
     {
       $sfGuardUser = $user->getGuardUser();
-      sfFacebook::getGuardAdapter()->setUserFacebookUid($sfGuardUser, sfFacebook::getFacebookClient()->get_loggedin_user());
+      sfFacebook::getGuardAdapter()->setUserFacebookUid($sfGuardUser, sfFacebook::getFacebookClient()->getUser());
       $sfGuardUser->save();
     }
     else


### PR DESCRIPTION
Hi Fabrice, I've fixed a problem in the executeSignin() method related to the use of get_loggedin_user() method not more in the php-sdk. Now an existent and logged in user (already in sfGuardUser) can click on the button to link his account to FB. Then he can login with just one click.

Cheers
Daniel
